### PR TITLE
replace deprecated imports of bootstrap sub files and add bs5 imports

### DIFF
--- a/apps/core/static/scss/_bootstrap.scss
+++ b/apps/core/static/scss/_bootstrap.scss
@@ -1,54 +1,44 @@
-//
-// liqd bootstrap imports
-// --------------------------------------------------
-
-// Core variables and mixins
-@import '~bootstrap/scss/functions';
+// Configuration
+@import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/maps";
 @import "~bootstrap/scss/utilities";
 
-// Reset and dependencies
-//@import "~bootstrap/scss/normalize";
+// Layout & components
+@import "~bootstrap/scss/root";
 @import "~bootstrap/scss/reboot";
-//@import "~bootstrap/scss/print";
-//@import "~bootstrap/scss/glyphicons";
-
-// Core CSS
-//@import "~bootstrap/scss/scaffolding";
 @import "~bootstrap/scss/type";
-//@import "~bootstrap/scss/code";
+@import "~bootstrap/scss/images";
+@import "~bootstrap/scss/containers";
 @import "~bootstrap/scss/grid";
-//@import "~bootstrap/scss/tables";
-//@import "~bootstrap/scss/forms";
+@import "~bootstrap/scss/tables";
+@import "~bootstrap/scss/forms";
 @import "~bootstrap/scss/buttons";
-
-// Components
-//@import "~bootstrap/scss/component-animations";
-//@import "~bootstrap/scss/dropdowns";
-//@import "~bootstrap/scss/button-groups";
-//@import "~bootstrap/scss/input-groups";
+@import "~bootstrap/scss/transitions";
+@import "~bootstrap/scss/dropdown";
+@import "~bootstrap/scss/button-group";
 @import "~bootstrap/scss/nav";
 @import "~bootstrap/scss/navbar";
-@import "~bootstrap/scss/transitions";
-//@import "~bootstrap/scss/pagination";
-//@import "~bootstrap/scss/pager";
-//@import "~bootstrap/scss/labels";
-//@import "~bootstrap/scss/badges";
-//@import "~bootstrap/scss/jumbotron";
-//@import "~bootstrap/scss/thumbnails";
-//@import "~bootstrap/scss/alerts";
-//@import "~bootstrap/scss/progress-bars";
-//@import "~bootstrap/scss/media";
-//@import "~bootstrap/scss/list-group";
-//@import "~bootstrap/scss/panels";
-//@import "~bootstrap/scss/responsive-embed";
-//@import "~bootstrap/scss/wells";
-//@import "~bootstrap/scss/close";
+@import "~bootstrap/scss/card";
+@import "~bootstrap/scss/accordion";
+@import "~bootstrap/scss/breadcrumb";
+@import "~bootstrap/scss/pagination";
+@import "~bootstrap/scss/badge";
+@import "~bootstrap/scss/alert";
+@import "~bootstrap/scss/progress";
+@import "~bootstrap/scss/list-group";
+@import "~bootstrap/scss/close";
+@import "~bootstrap/scss/toasts";
+@import "~bootstrap/scss/modal";
+@import "~bootstrap/scss/tooltip";
+@import "~bootstrap/scss/popover";
+@import "~bootstrap/scss/carousel";
+@import "~bootstrap/scss/spinners";
+@import "~bootstrap/scss/offcanvas";
 
-// Components w/ JavaScript
-//@import "~bootstrap/scss/modals";
-//@import "~bootstrap/scss/tooltip";
-//@import "~bootstrap/scss/popovers";
-//@import "~bootstrap/scss/carousel";
+// Helpers
+@import "~bootstrap/scss/helpers";
+
+// Utilities
+@import "~bootstrap/scss/utilities/api";


### PR DESCRIPTION
some of the imports changed with BS5, this needs testing with complete content, to avoid bootstrap styles used, but not loaded/imported.

The obvious issue is fixed by importing `.../scss/containers` in `_bootstrap.scss`