### PR TITLE
simplify webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "devDependencies": {
     "eslint": "8.22.0",
     "eslint-config-standard": "17.0.0",
+    "eslint-plugin-compat": "4.0.2",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "6.0.0",
@@ -45,7 +46,10 @@
     "precommit": "make lint"
   },
   "eslintConfig": {
-    "extends": "standard",
+    "extends": [
+      "standard",
+      "plugin:compat/recommended"
+    ],
     "rules": {
       "indent": [
         "error",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -27,15 +27,6 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.jsx?$/,
-        exclude: /node_modules\/(?!(bootstrap)\/).*/,
-        loader: 'babel-loader',
-        options: {
-          presets: ['@babel/preset-env', '@babel/preset-react'].map(require.resolve),
-          plugins: ['@babel/plugin-transform-runtime', '@babel/plugin-transform-modules-commonjs']
-        }
-      },
-      {
         test: /\.s?css$/,
         use: [
           {
@@ -49,7 +40,7 @@ module.exports = {
             options: {
               postcssOptions: {
                 plugins: [
-                  require('autoprefixer')
+                  autoprefixer
                 ]
               }
             }


### PR DESCRIPTION
* remove babel-loader, we don't use fancy stuff and don't need to
  support very old browsers
* add eslint package which warns us if we use unsupported apis