### PR TITLE
translations: add new string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,6 @@ lint-fix:
 .PHONY: po
 po:
 	$(VIRTUAL_ENV)/bin/python manage.py makemessages --all --extension html,email,py,js,jsx --ignore venv --ignore node_modules
-	msgen locale/de/LC_MESSAGES/django.po -o locale/de/LC_MESSAGES/django.po
 
 .PHONY: mo
 mo:

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-06 17:04+0200\n"
+"POT-Creation-Date: 2023-02-28 11:40+0100\n"
 "PO-Revision-Date: 2022-09-06 15:40+0000\n"
 "Last-Translator: maxliqd <m.westbrock@liqd.net>\n"
-"Language-Team: German <https://trans.liqd.net/projects/"
-"liquid-democracy-website/main/de/>\n"
+"Language-Team: German <https://trans.liqd.net/projects/liquid-democracy-"
+"website/main/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,6 +191,10 @@ msgstr "Internal Server Error. Bitte später erneut versuchen."
 #: apps/core/templates/base.html:29
 msgid "Skip to content "
 msgstr "Skip to content "
+
+#: apps/core/templates/blocks/block_video.html:47
+msgid "Media transcript"
+msgstr ""
 
 #: apps/core/templates/core/home_page.html:7
 msgid "Homepage of Liquid Democracy"


### PR DESCRIPTION
There is only one new string. But I guess we can remove the old ones?

And I find it a bit weird that we do add the English string as translation to the German file https://github.com/liqd/liqd-site/blob/7ff618a22339e771a37056df52b5937e5139e6c6/Makefile#L95 Any ideas why? Should we ask @hello-kathi if we should or shouldn't do that?