### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,16 +8,16 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-02-28 11:40+0100\n"
-"PO-Revision-Date: 2022-09-06 15:40+0000\n"
-"Last-Translator: maxliqd <m.westbrock@liqd.net>\n"
-"Language-Team: German <https://trans.liqd.net/projects/liquid-democracy-"
-"website/main/de/>\n"
+"PO-Revision-Date: 2023-03-01 11:52+0000\n"
+"Last-Translator: Weblate Admin <webmaster@liqd.net>\n"
+"Language-Team: German <https://trans.liqd.net/projects/"
+"liquid-democracy-website/main/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14\n"
+"X-Generator: Weblate 4.14.1\n"
 
 #: apps/academy/choices.py:8
 msgid "Liquid Democracy: Theory & Vision"
@@ -194,7 +194,7 @@ msgstr "Skip to content "
 
 #: apps/core/templates/blocks/block_video.html:47
 msgid "Media transcript"
-msgstr ""
+msgstr "Transkript"
 
 #: apps/core/templates/core/home_page.html:7
 msgid "Homepage of Liquid Democracy"


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://trans.liqd.net) for [Liquid Democracy Website/main](https://trans.liqd.net/projects/liquid-democracy-website/main/).



Current translation status:

![Weblate translation status](https://trans.liqd.net/widgets/liquid-democracy-website/-/main/horizontal-auto.svg)