### PR TITLE
fix issue with home logo canvas

### DIFF
--- a/apps/core/static/scss/_home-logo.scss
+++ b/apps/core/static/scss/_home-logo.scss
@@ -1,13 +1,14 @@
 .home-logo {
+    position: relative;
     height: 70vh;
     width: 100vw;
+    z-index: -1;
 }
 
 .home-logo__canvas {
     position: fixed;
     top: 0;
     left: 0;
-
     transition: opacity 0.1s;
 }
 

--- a/changelog/8267.md
+++ b/changelog/8267.md
@@ -1,0 +1,3 @@
+### Changed
+
+`_home-logo-scss` fix issues with logo container z-index


### PR DESCRIPTION
restore ability to select page content, which has been block by canvas

![Screenshot 2024-07-08 at 14-27-04 Homepage Liquid Democracy](https://github.com/liqd/liqd-site/assets/8156337/3c09210b-e0bf-41f0-b7ca-95cd53775a35)
